### PR TITLE
fix: courseform data property reference dept-department

### DIFF
--- a/views/courseForm.ejs
+++ b/views/courseForm.ejs
@@ -48,7 +48,7 @@
                 <th>COLLEGE:</th>
                 <td><%=data[0].College%></td>
                 <th>DEPARTMENT:</th>
-                <td><%=data[0].Dept%></td>
+                <td><%=data[0].Department%></td>
               </tr>
               <tr>
                 <th>PROGRAMME:</th>


### PR DESCRIPTION
I changed the dept property to department in the courseform.ejs file so as to reference the department of the student not the department of the course registered